### PR TITLE
docs: document the electrum interface as SSL-only; 0.11.1:7 → 0.11.1:8

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ Total time is hardware-dependent and can take many hours. The Electrum port is n
 
 ## Network Access and Interfaces
 
-| Interface    | Port  | Protocol                | Purpose                          |
-| ------------ | ----- | ----------------------- | -------------------------------- |
-| Electrum     | 50001 | TCP (Electrum protocol) | Wallet connections (unencrypted) |
-| Electrum SSL | 50002 | TCP+SSL                 | Wallet connections (encrypted)   |
+| Interface | Internal Port | External Port | Protocol | Purpose |
+| --------- | ------------- | ------------- | -------- | ------- |
+| Main      | 50001         | 50002         | TCP+SSL (Electrum protocol) | Wallet connections |
+
+The interface is SSL-only: electrs itself listens unencrypted on 50001 inside the container, and StartOS terminates TLS at the platform edge on 50002 (`addSsl` on the bind, `secure: null`). No plain-TCP port is exposed externally — this is deliberate (Electrum traffic carries address queries; all major wallets support `ssl://`), and it matches the Fulcrum package.
 
 **Access methods (StartOS 0.4.0):**
 
@@ -250,8 +251,8 @@ architectures: [x86_64, aarch64]
 volumes:
   main: /data
 ports:
-  electrum: 50001
-  electrum_ssl: 50002
+  electrum_internal: 50001 (not exposed externally)
+  electrum_ssl: 50002 (StartOS-terminated TLS; the only external port)
 dependencies:
   - bitcoind (required)
 fixed_config:

--- a/instructions.md
+++ b/instructions.md
@@ -9,7 +9,7 @@ Electrs needs a fully-synced Bitcoin archival node to do anything useful. Instal
 ## What you get on StartOS
 
 - An **Electrum protocol server** that indexes the Bitcoin blockchain and answers wallet queries.
-- A **Main** interface exposing both plain TCP (port 50001) and TLS (port 50002), reachable over LAN, `.local`, Tor, and any custom domains you've configured.
+- A **Main** interface exposing the Electrum protocol over SSL (port 50002), reachable over LAN, `.local`, Tor, and any custom domains you've configured. Connections are SSL-only — StartOS terminates TLS with the device's certificate, and all major wallets (Electrum, Sparrow, BlueWallet, etc.) support `ssl://` servers.
 - Automatic wiring to your StartOS Bitcoin Core node — RPC, P2P, and cookie authentication are all configured for you. You do not point Electrs at Bitcoin yourself.
 - A RocksDB address index stored under the `main` volume (excluded from backups; it rebuilds itself if you restore).
 
@@ -18,13 +18,13 @@ Electrs needs a fully-synced Bitcoin archival node to do anything useful. Instal
 1. Install **Bitcoin Core** first if it isn't already installed.
 2. Start Electrs. On first run it will report **Waiting for Bitcoin to start** or **Waiting for Bitcoin to finish syncing** until your Bitcoin node has completed its initial block download. This can take a long time on a fresh node.
 3. Once Bitcoin is fully synced, Electrs will switch to **Electrs is building its address index** while it builds its own index. This typically takes several hours on first run.
-4. When the **Sync Progress** health check reports **Fully synced**, point your Electrum wallet at the **Main** interface (TLS on port 50002 is recommended).
+4. When the **Sync Progress** health check reports **Fully synced**, point your Electrum wallet at the **Main** interface (SSL, port 50002).
 
 ## Using Electrs
 
 ### Main interface
 
-The **Main** interface is the Electrum protocol endpoint. Copy its address from the **Dashboard** tab into your Electrum wallet's server settings — most wallets default to the TLS port. Electrs serves all standard Electrum protocol queries: balances, history, transaction lookups, mempool tracking.
+The **Main** interface is the Electrum protocol endpoint. Copy its address from the **Dashboard** tab into your Electrum wallet's server settings as an `ssl://` server. If your wallet asks about the certificate (it is issued by your device's StartOS root CA), accept or pin it — Electrum pins it on first use, Sparrow shows a one-time trust prompt. Electrs serves all standard Electrum protocol queries: balances, history, transaction lookups, mempool tracking.
 
 ### Actions
 

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -4,6 +4,9 @@ import { port } from './utils'
 
 export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
   const multihost = sdk.MultiHost.of(effects, 'electrum')
+  // SSL-only by design: with secure: null the OS exposes just the TLS port
+  // (50002) on regular LAN gateways. Electrum traffic carries address queries,
+  // all major wallets support ssl://, and this matches the Fulcrum package.
   const mainMultiOrigin = await multihost.bindPort(port, {
     protocol: null,
     addSsl: {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,18 +4,13 @@ import { tomlFile } from '../fileModels/electrs.toml'
 import { LogFilters } from '../utils'
 
 export const current = VersionInfo.of({
-  version: '0.11.1:7',
+  version: '0.11.1:8',
   releaseNotes: {
-    en_US: `- Fixes the sync status falsely reporting "Fully synced" while the address index was still building.
-- Shows an accurate Electrum server status during startup.`,
-    es_ES: `- Corrige el estado de sincronización que indicaba falsamente "Totalmente sincronizado" mientras aún se construía el índice de direcciones.
-- Muestra un estado preciso del servidor Electrum durante el inicio.`,
-    de_DE: `- Behebt die Synchronisierungsanzeige, die fälschlicherweise „Vollständig synchronisiert" meldete, während der Adressindex noch aufgebaut wurde.
-- Zeigt während des Starts einen korrekten Status des Electrum-Servers an.`,
-    pl_PL: `- Naprawia status synchronizacji, który błędnie pokazywał „W pełni zsynchronizowano", gdy indeks adresów był jeszcze budowany.
-- Pokazuje dokładny status serwera Electrum podczas uruchamiania.`,
-    fr_FR: `- Corrige l'état de synchronisation indiquant à tort « Entièrement synchronisé » alors que l'index d'adresses était encore en construction.
-- Affiche un état précis du serveur Electrum au démarrage.`,
+    en_US: `- Corrects the instructions: the Electrum interface is SSL-only (port 50002, certificate from your device's StartOS root CA). The previously documented plain-TCP port (50001) was never exposed externally and is not intended to be — all major wallets support ssl:// servers.`,
+    es_ES: `- Corrige las instrucciones: la interfaz Electrum es solo SSL (puerto 50002, certificado de la CA raíz de StartOS de su dispositivo). El puerto TCP sin cifrar documentado anteriormente (50001) nunca estuvo expuesto externamente y no está previsto que lo esté: todas las carteras principales admiten servidores ssl://.`,
+    de_DE: `- Korrigiert die Anleitung: Die Electrum-Schnittstelle ist nur über SSL erreichbar (Port 50002, Zertifikat von der StartOS-Root-CA Ihres Geräts). Der zuvor dokumentierte unverschlüsselte TCP-Port (50001) war nie extern verfügbar und soll es auch nicht sein — alle gängigen Wallets unterstützen ssl://-Server.`,
+    pl_PL: `- Poprawia instrukcję: interfejs Electrum działa wyłącznie przez SSL (port 50002, certyfikat z głównego CA StartOS urządzenia). Wcześniej udokumentowany nieszyfrowany port TCP (50001) nigdy nie był wystawiony na zewnątrz i nie jest to planowane — wszystkie popularne portfele obsługują serwery ssl://.`,
+    fr_FR: `- Corrige les instructions : l'interface Electrum est uniquement SSL (port 50002, certificat de l'autorité racine StartOS de votre appareil). Le port TCP en clair documenté précédemment (50001) n'a jamais été exposé à l'extérieur et n'est pas destiné à l'être — tous les portefeuilles majeurs prennent en charge les serveurs ssl://.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

The instructions and README claimed the Main interface exposes both plain TCP (50001) and TLS (50002) over LAN. In reality — and by design — only the TLS port is exposed externally: the bind uses `secure: null` + `addSsl`, which under StartOS semantics exposes just the SSL port on regular LAN gateways (the plain port would only appear on gateways marked secure, i.e. loopback/bridge).

After reviewing whether to expose plain TCP instead (see the analysis in Start9Labs/public-pool-startos#15, where the same bind semantics were traced through the OS source), SSL-only is the right posture here:

- Electrum traffic carries address/scripthash queries — encrypt by default.
- All major wallets support `ssl://` with the StartOS device cert (Electrum pins on first use, Sparrow shows a one-time trust prompt; the cert SANs cover `.local` and the device IPs).
- Fulcrum, the Start9-run Electrum server package, ships the same way and documents it.

So this corrects the docs to match the (intended) behavior instead of changing the behavior to match the docs, and adds a comment to `interfaces.ts` so the bind options aren't mistaken for a bug. Ships as `0.11.1:8` since `instructions.md` is packed into the s9pk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)