### PR TITLE
fix: strip the legacy auth key from electrs.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Total time is hardware-dependent and can take many hours. The Electrum port is n
 
 | Setting              | Upstream Method | StartOS Method                                                    |
 | -------------------- | --------------- | ----------------------------------------------------------------- |
+| `auth`               | Config/CLI      | Never set — mutually exclusive with `cookie_file`                 |
 | `cookie_file`        | Config/CLI      | Fixed: `/mnt/bitcoind/.cookie`                                    |
 | `daemon_rpc_addr`    | Config/CLI      | Auto: bitcoind RPC over the LXC bridge                            |
 | `daemon_p2p_addr`    | Config/CLI      | Auto: bitcoind whitelisted P2P (`peer-local`) over the LXC bridge |

--- a/startos/fileModels/electrs.toml.ts
+++ b/startos/fileModels/electrs.toml.ts
@@ -2,6 +2,8 @@ import { FileHelper, z } from '@start9labs/start-sdk'
 import { sdk } from '../sdk'
 
 export const shape = z.object({
+  // Stripped: electrs exits if auth and cookie_file are both set
+  auth: z.undefined().catch(undefined),
   cookie_file: z
     .literal('/mnt/bitcoind/.cookie')
     .catch('/mnt/bitcoind/.cookie'),

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,23 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.11.1:15',
+  version: '0.11.1:16',
   releaseNotes: {
-    en_US: `Stops Electrs reloading at the moment Bitcoin Core goes away.
+    en_US: `Fixes Electrs failing to start after an update from StartOS 0.3.5.1.
 
-Electrs reloads when Bitcoin Core issues new RPC credentials, which it does on every restart. That reload was previously triggered as soon as Bitcoin Core *began* shutting down — while its RPC was already unreachable — so Electrs was restarted against a backend that was not there yet, and Electrs exits when it cannot reach Bitcoin. It now reloads only once Bitcoin Core is back up and has published new credentials.`,
-    es_ES: `Evita que Electrs se recargue justo cuando Bitcoin Core desaparece.
+On StartOS 0.3.5.1 Electrs authenticated to Bitcoin with an RPC username and password, kept in its own config file. StartOS 0.4.0 authenticates with Bitcoin's cookie file instead, but the old username and password survived the update, and Electrs refuses to start when it is handed both: "ambiguous configuration - auth and cookie_file can't be specified at the same time". The leftover credentials are now removed, and Electrs starts normally.`,
+    es_ES: `Corrige el fallo de arranque de Electrs tras actualizar desde StartOS 0.3.5.1.
 
-Electrs se recarga cuando Bitcoin Core emite nuevas credenciales RPC, algo que hace en cada reinicio. Esa recarga se activaba en cuanto Bitcoin Core *empezaba* a apagarse — cuando su RPC ya era inalcanzable —, así que Electrs arrancaba contra un backend que todavía no estaba, y Electrs se cierra cuando no puede alcanzar a Bitcoin. Ahora se recarga solo cuando Bitcoin Core ha vuelto y ha publicado nuevas credenciales.`,
-    de_DE: `Verhindert, dass Electrs genau dann neu lädt, wenn Bitcoin Core verschwindet.
+En StartOS 0.3.5.1, Electrs se autenticaba ante Bitcoin con un usuario y una contraseña RPC, guardados en su propio archivo de configuración. StartOS 0.4.0 se autentica mediante el archivo cookie de Bitcoin, pero el usuario y la contraseña antiguos sobrevivían a la actualización, y Electrs se niega a arrancar cuando recibe ambos: "ambiguous configuration - auth and cookie_file can't be specified at the same time". Las credenciales sobrantes ahora se eliminan y Electrs arranca con normalidad.`,
+    de_DE: `Behebt, dass Electrs nach einem Update von StartOS 0.3.5.1 nicht mehr startet.
 
-Electrs lädt neu, sobald Bitcoin Core neue RPC-Zugangsdaten ausgibt — was bei jedem Neustart geschieht. Dieses Neuladen wurde bisher ausgelöst, sobald Bitcoin Core mit dem Herunterfahren *begann* — während dessen RPC bereits nicht mehr erreichbar war. Electrs startete also gegen ein Backend, das noch nicht da war, und Electrs beendet sich, wenn es Bitcoin nicht erreichen kann. Es lädt jetzt erst neu, wenn Bitcoin Core wieder läuft und neue Zugangsdaten veröffentlicht hat.`,
-    pl_PL: `Zapobiega przeładowaniu Electrs dokładnie w chwili, gdy znika Bitcoin Core.
+Unter StartOS 0.3.5.1 authentifizierte sich Electrs bei Bitcoin mit RPC-Benutzername und -Passwort, die in seiner eigenen Konfigurationsdatei standen. StartOS 0.4.0 authentifiziert sich stattdessen über Bitcoins Cookie-Datei, doch die alten Zugangsdaten überlebten das Update — und Electrs verweigert den Start, wenn ihm beides vorliegt: "ambiguous configuration - auth and cookie_file can't be specified at the same time". Die übrig gebliebenen Zugangsdaten werden jetzt entfernt, und Electrs startet wieder normal.`,
+    pl_PL: `Naprawia sytuację, w której Electrs nie uruchamia się po aktualizacji z StartOS 0.3.5.1.
 
-Electrs przeładowuje się, gdy Bitcoin Core wydaje nowe dane uwierzytelniające RPC, co robi przy każdym restarcie. Dotąd to przeładowanie uruchamiało się, gdy tylko Bitcoin Core *zaczynał* się wyłączać — a jego RPC było już nieosiągalne — więc Electrs startował wobec backendu, którego jeszcze nie było, a Electrs kończy pracę, gdy nie może połączyć się z Bitcoinem. Teraz przeładowuje się dopiero wtedy, gdy Bitcoin Core wróci i opublikuje nowe dane uwierzytelniające.`,
-    fr_FR: `Empêche Electrs de se recharger au moment précis où Bitcoin Core disparaît.
+W StartOS 0.3.5.1 Electrs uwierzytelniał się w Bitcoinie nazwą użytkownika i hasłem RPC, zapisanymi we własnym pliku konfiguracyjnym. StartOS 0.4.0 uwierzytelnia się zamiast tego plikiem cookie Bitcoina, ale stara nazwa użytkownika i hasło przetrwały aktualizację, a Electrs odmawia uruchomienia, gdy otrzyma jedno i drugie: "ambiguous configuration - auth and cookie_file can't be specified at the same time". Pozostałe dane uwierzytelniające są teraz usuwane i Electrs uruchamia się normalnie.`,
+    fr_FR: `Corrige l'impossibilité de démarrer Electrs après une mise à jour depuis StartOS 0.3.5.1.
 
-Electrs se recharge lorsque Bitcoin Core émet de nouveaux identifiants RPC, ce qu'il fait à chaque redémarrage. Ce rechargement était jusqu'ici déclenché dès que Bitcoin Core *commençait* à s'arrêter — alors que son RPC était déjà injoignable —, si bien qu'Electrs redémarrait face à un backend encore absent, et Electrs s'arrête lorsqu'il ne peut pas joindre Bitcoin. Il ne se recharge désormais qu'une fois Bitcoin Core revenu et de nouveaux identifiants publiés.`,
+Sous StartOS 0.3.5.1, Electrs s'authentifiait auprès de Bitcoin avec un nom d'utilisateur et un mot de passe RPC, inscrits dans son propre fichier de configuration. StartOS 0.4.0 s'authentifie désormais avec le fichier cookie de Bitcoin, mais l'ancien identifiant et son mot de passe survivaient à la mise à jour, et Electrs refuse de démarrer lorsqu'on lui fournit les deux : "ambiguous configuration - auth and cookie_file can't be specified at the same time". Les identifiants résiduels sont maintenant supprimés et Electrs démarre normalement.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
Electrs fails to start after an update from StartOS 0.3.5.1:

```
health check Electrs failed: Electrs Daemon crashed
Error: ambiguous configuration - auth and cookie_file can't be specified at the same time
```

The 0.3.5.1 package wrote `electrs.toml` from a Rust configurator template that opened with `auth = "<rpcuser>:<rpcpass>"`. That file lives at the root of the `main` volume, which survives the update. Every write path here is `FileHelper.merge`, which preserves keys the shape doesn't name, so `auth` stayed put while `cookie_file` was filled in from its `.catch()` default — and electrs rejects both at once (`electrs/src/config.rs`, `match (config.auth, config.cookie_file)`).

Through 0.11.1:8 the migration used `tomlFile.write()`, a whole-file replacement that dropped the key. Freezing it into `v0.11.1_9.ts` changed it to `merge`, so the collision came back for anyone updating from 0.3.5.1 onto :10 or later.

Declaring `auth` in the shape makes it a key `merge` owns, so validation coerces it away on every write path — `seedFiles`, `main`, the config action — rather than only along one migration edge. A 0.3.5.1 backup restored onto 0.4.0 is covered too.

## Test plan

Only useful on a node that came from StartOS 0.3.5.1 with electrs installed — a fresh install never had an `auth` line.

1. Confirm the bad state on a node currently failing: `start-cli package attach electrs -n electrs -- cat /data/electrs.toml` shows both an `auth = …` line and `cookie_file = "/mnt/bitcoind/.cookie"`, and the service logs end with `ambiguous configuration`.
2. Install this build and start electrs.
3. Re-read the config — the `auth` line is gone, `cookie_file` remains, and `log_filters` / `index_batch_size` / `index_lookup_limit` keep the values they had.
4. Electrs reaches "Electrum server is ready and accepting connections", and the index resumes rather than rebuilding.
5. Run **Configure**, change the log level, save — the `auth` line does not come back.

Verified so far: `tsc --noEmit`, plus a round trip of a legacy 0.3.5.1 `electrs.toml` through the SDK's own `z.deepLoose` / `fileMerge` / `TOML.stringify` (drops `auth`, keeps everything else, idempotent on re-merge). Not yet installed on a box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)